### PR TITLE
Logging arguments rearrange

### DIFF
--- a/src/server/Allserver.js
+++ b/src/server/Allserver.js
@@ -66,7 +66,7 @@ module.exports = require("stampit")({
                 result = await ctx.procedure(ctx.arg, ctx);
             } catch (err) {
                 const code = err.code || "ALLSERVER_PROCEDURE_ERROR";
-                this.logger.error(code, err);
+                this.logger.error(err, code);
                 ctx.error = err;
                 ctx.result = {
                     success: false,
@@ -104,7 +104,7 @@ module.exports = require("stampit")({
                     }
                 } catch (err) {
                     const code = err.code || "ALLSERVER_MIDDLEWARE_ERROR";
-                    this.logger.error(code, err);
+                    this.logger.error(err, code);
                     ctx.error = err;
                     ctx.result = {
                         success: false,

--- a/test/server/Allserver.test.js
+++ b/test/server/Allserver.test.js
@@ -116,7 +116,7 @@ describe("Allserver", () => {
             let logged = false;
             const server = Allserver({
                 logger: {
-                    error(code, err) {
+                    error(err, code) {
                         assert.strictEqual(code, "ALLSERVER_PROCEDURE_ERROR");
                         assert.strictEqual(err.message, "'undefined' is not a function");
                         logged = true;
@@ -294,7 +294,7 @@ describe("Allserver", () => {
                 let logged = false;
                 const server = Allserver({
                     logger: {
-                        error(code, err) {
+                        error(err, code) {
                             assert.strictEqual(code, "ALLSERVER_MIDDLEWARE_ERROR");
                             assert.strictEqual(err.message, "Handle me please");
                             logged = true;
@@ -404,7 +404,7 @@ describe("Allserver", () => {
                 let logged = false;
                 const server = Allserver({
                     logger: {
-                        error(code, err) {
+                        error(err,code) {
                             assert.strictEqual(code, "ALLSERVER_MIDDLEWARE_ERROR");
                             assert.strictEqual(err.message, "Handle me please");
                             logged = true;


### PR DESCRIPTION
Most loggers propose to log errors or objects as first arguments and then a message.

See https://github.com/pinojs/pino/blob/master/docs/api.md and 
https://github.com/trentm/node-bunyan#log-method-api