### PR TITLE
Implement call meta within the arg._ property

### DIFF
--- a/README.md
+++ b/README.md
@@ -911,7 +911,7 @@ const client = AllserverClient({
     ctx.http.headers.authorization = "Basic my-token";
   },
   async after(ctx) {
-    if (ctx.error) console.error(ctx.error) else console.log(ctx.result);
+    if (ctx.error) console.error(ctx.error); else console.log(ctx.result);
   },
 });
 ```

--- a/src/client/AllserverClient.js
+++ b/src/client/AllserverClient.js
@@ -263,6 +263,10 @@ module.exports = require("stampit")({
         },
 
         async call(procedureName, arg) {
+            if (!arg) arg = {};
+            if (!arg._) arg._ = {};
+            arg._.procedureName = procedureName;
+
             const transport = this[p].transport;
             const defaultCtx = { procedureName, arg, client: this };
             const ctx = transport.createCallContext(defaultCtx);

--- a/src/client/LambdaClientTransport.js
+++ b/src/client/LambdaClientTransport.js
@@ -28,13 +28,10 @@ module.exports = require("./ClientTransport").compose({
             return result;
         },
 
-        async call({ procedureName, lambda }) {
+        async call(ctx) {
             let promise = this.awsSdkLambdaClient.invoke({
                 FunctionName: this.uri.substring("lambda://".length),
-                Payload: JSON.stringify({
-                    callContext: { ...lambda.callContext, procedureName },
-                    callArg: lambda.callArg,
-                }),
+                Payload: JSON.stringify(ctx.arg),
             });
             if (typeof promise.promise === "function") promise = promise.promise(); // AWS SDK v2 adoption
             const invocationResponse = await promise;
@@ -44,10 +41,7 @@ module.exports = require("./ClientTransport").compose({
         createCallContext(defaultCtx) {
             return {
                 ...defaultCtx,
-                lambda: {
-                    callContext: {},
-                    callArg: defaultCtx.arg,
-                },
+                lambda: {},
             };
         },
     },

--- a/src/server/Allserver.js
+++ b/src/server/Allserver.js
@@ -123,6 +123,10 @@ module.exports = require("stampit")({
             ctx.isIntrospection = this.transport.isIntrospection(ctx);
             if (!ctx.isIntrospection && ctx.procedureName) ctx.procedure = this.procedures[ctx.procedureName];
 
+            if (!ctx.arg) ctx.arg = {};
+            if (!ctx.arg._) ctx.arg._ = {};
+            if (!ctx.arg._.procedureName) ctx.arg._.procedureName = ctx.procedureName;
+
             await this._callMiddlewares(ctx, "before");
 
             if (!ctx.result) {

--- a/src/server/LambdaTransport.js
+++ b/src/server/LambdaTransport.js
@@ -21,7 +21,9 @@ module.exports = require("./Transport").compose({
                     return false;
                 }
             } else {
-                ctx.arg = ctx.lambda.invoke || {};
+                // TODO: change to this during the next major release:
+                //  ctx.arg = ctx.lambda.invoke || {};
+                ctx.arg = ctx.lambda.invoke.callArg || ctx.lambda.invoke || {};
                 return true;
             }
         },
@@ -54,7 +56,11 @@ module.exports = require("./Transport").compose({
                             headers: event?.headers,
                         };
                     } else {
-                        lambda.invoke = event || {};
+                        // TODO: change to this during the next major release:
+                        //  lambda.invoke = event || {};
+                        lambda.invoke = event?.callArg
+                            ? { callContext: event?.callContext, callArg: event?.callArg }
+                            : event || {};
                     }
 
                     this._handleRequest({ ...defaultCtx, lambda });
@@ -64,8 +70,9 @@ module.exports = require("./Transport").compose({
 
         getProcedureName(ctx) {
             const { isHttp, http, invoke } = ctx.lambda;
-            if (isHttp) return http.path.substr(1);
-            return invoke._?.procedureName || ""; // if no procedureName then it's an introspection
+            // TODO: change to this during the next major release:
+            //  return (isHttp ? http.path.substr(1) : invoke._?.procedureName) || ""; // if no procedureName then it's an introspection
+            return isHttp ? http.path.substr(1) : invoke.callContext?.procedureName || invoke._?.procedureName || ""; // if no procedureName then it's an introspection
         },
 
         isIntrospection(ctx) {

--- a/src/server/LambdaTransport.js
+++ b/src/server/LambdaTransport.js
@@ -21,7 +21,7 @@ module.exports = require("./Transport").compose({
                     return false;
                 }
             } else {
-                ctx.arg = ctx.lambda.invoke.callArg || {};
+                ctx.arg = ctx.lambda.invoke || {};
                 return true;
             }
         },
@@ -54,7 +54,7 @@ module.exports = require("./Transport").compose({
                             headers: event?.headers,
                         };
                     } else {
-                        lambda.invoke = { callContext: event?.callContext, callArg: event?.callArg };
+                        lambda.invoke = event || {};
                     }
 
                     this._handleRequest({ ...defaultCtx, lambda });
@@ -64,7 +64,8 @@ module.exports = require("./Transport").compose({
 
         getProcedureName(ctx) {
             const { isHttp, http, invoke } = ctx.lambda;
-            return isHttp ? http.path.substr(1) : invoke.callContext?.procedureName;
+            if (isHttp) return http.path.substr(1);
+            return invoke._?.procedureName || ""; // if no procedureName then it's an introspection
         },
 
         isIntrospection(ctx) {

--- a/test/client/AllserverClient.test.js
+++ b/test/client/AllserverClient.test.js
@@ -213,7 +213,7 @@ describe("AllserverClient", () => {
                 },
                 async call({ procedureName, arg }) {
                     assert.strictEqual(procedureName, "getRates");
-                    assert.deepStrictEqual(arg, { a: 1 });
+                    assert.deepStrictEqual(arg, { a: 1, _: { procedureName: "getRates" } });
                     return { success: true, code: "CALLED", message: "A is good", b: 42 };
                 },
             });
@@ -244,7 +244,7 @@ describe("AllserverClient", () => {
                     },
                     async call({ procedureName, arg }) {
                         assert.strictEqual(procedureName, "getRates");
-                        assert.deepStrictEqual(arg, { a: 1 });
+                        assert.deepStrictEqual(arg, { a: 1, _: { procedureName: "getRates" } });
                         return { success: true, code: "CALLED", message: "A is good", b: 42 };
                     },
                 });
@@ -256,7 +256,7 @@ describe("AllserverClient", () => {
                         assert(!ctx.procedureName);
                     } else {
                         assert.strictEqual(ctx.procedureName, "getRates");
-                        assert.deepStrictEqual(ctx.arg, { a: 1 });
+                        assert.deepStrictEqual(ctx.arg, { a: 1, _: { procedureName: "getRates" } });
                     }
                     beforeCalled += 1;
                 }
@@ -340,7 +340,7 @@ describe("AllserverClient", () => {
                     },
                     async call({ procedureName, arg }) {
                         assert.strictEqual(procedureName, "getRates");
-                        assert.deepStrictEqual(arg, { a: 1 });
+                        assert.deepStrictEqual(arg, { a: 1, _: { procedureName: "getRates" } });
                         return { success: true, code: "CALLED", message: "A is good", b: 42 };
                     },
                 });
@@ -352,7 +352,7 @@ describe("AllserverClient", () => {
                         assert(!ctx.procedureName);
                     } else {
                         assert.strictEqual(ctx.procedureName, "getRates");
-                        assert.deepStrictEqual(ctx.arg, { a: 1 });
+                        assert.deepStrictEqual(ctx.arg, { a: 1, _: { procedureName: "getRates" } });
                         assert.deepStrictEqual(ctx.result, {
                             success: true,
                             code: "CALLED",
@@ -479,7 +479,7 @@ describe("AllserverClient", () => {
                 },
                 async call({ procedureName, arg }) {
                     assert.strictEqual(procedureName, "foo");
-                    assert.deepStrictEqual(arg, { a: 1 });
+                    assert.deepStrictEqual(arg, { a: 1, _: { procedureName: "foo" } });
                     return { success: true, code: "CALLED_A", message: "A is good", b: 42 };
                 },
             });
@@ -498,7 +498,7 @@ describe("AllserverClient", () => {
                 },
                 call({ procedureName, arg }) {
                     assert.strictEqual(procedureName, "foo");
-                    assert.deepStrictEqual(arg, { a: 1 });
+                    assert.deepStrictEqual(arg, { a: 1, _: { procedureName: "foo" } });
                     return { success: true, code: "CALLED_A", message: "A is good", b: 42 };
                 },
             });

--- a/test/server/Allserver.test.js
+++ b/test/server/Allserver.test.js
@@ -272,6 +272,7 @@ describe("Allserver", () => {
                     before(ctx) {
                         assert.strictEqual(this, server, "The `this` context must be the server itself");
                         assert.deepStrictEqual(ctx, {
+                            arg: { _: { procedureName: "testMethod" } },
                             callNumber: 0,
                             procedure: server.procedures.testMethod,
                             procedureName: "testMethod",
@@ -377,6 +378,7 @@ describe("Allserver", () => {
                     after(ctx) {
                         assert.strictEqual(this, server, "The `this` context must be the server itself");
                         assert.deepStrictEqual(ctx, {
+                            arg: { _: { procedureName: "testMethod" } },
                             callNumber: 0,
                             procedure: server.procedures.testMethod,
                             procedureName: "testMethod",
@@ -404,7 +406,7 @@ describe("Allserver", () => {
                 let logged = false;
                 const server = Allserver({
                     logger: {
-                        error(err,code) {
+                        error(err, code) {
                             assert.strictEqual(code, "ALLSERVER_MIDDLEWARE_ERROR");
                             assert.strictEqual(err.message, "Handle me please");
                             logged = true;


### PR DESCRIPTION
The CI fails due to some GitHub Actions recent changes. However, the unit tests still pass on windows (all versions of Node).